### PR TITLE
Add functions to list and remove used hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ potential to be confusing based on technical jargon (like
 If you decommission a server, you can return its hostname to the usable
 pool, thereby uncommenting it in the wordlist:
 
-    $ ./genhost -hostname
+    $ ./genhost -jester
 
 You can also print a list of the hostnames currently marked as in use:
 
     $ ./genhost ?
+    romeo.example.com
+    holiday.example.com
+    spiral.example.com
 
 For collaboration purposes, don't forget to commit the updated word list
 back to a shared Git repository so names do not get reused:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ pool, thereby uncommenting it in the wordlist:
 You can also print a list of the hostnames currently marked as in use:
 
     $ ./genhost ?
-    romeo.example.com
-    holiday.example.com
-    spiral.example.com
+    romeo
+    holiday
+    spiral
 
 For collaboration purposes, don't forget to commit the updated word list
 back to a shared Git repository so names do not get reused:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 Just run the script and provide the number of hostnames you'd like to
 generate:
 
-    $ ./genhost 4
+    $ ./genhost +4
     romeo.example.com
     holiday.example.com
     jester.example.com
@@ -22,6 +22,15 @@ All of those words will automatically be commented out in the word list
 and thus removed from the pool of future names. If a hostname has the
 potential to be confusing based on technical jargon (like
 `email.example.com`), simply ignore it and generate a replacement.
+
+If you decommission a server, you can return its hostname to the usable
+pool, thereby uncommenting it in the wordlist:
+
+    $ ./genhost -hostname
+
+You can also print a list of the hostnames currently marked as in use:
+
+    $ ./genhost ?
 
 For collaboration purposes, don't forget to commit the updated word list
 back to a shared Git repository so names do not get reused:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 Just run the script and provide the number of hostnames you'd like to
 generate:
 
-    $ ./genhost +4
+    $ ./genhost add 4
     romeo.example.com
     holiday.example.com
     jester.example.com
@@ -26,11 +26,11 @@ potential to be confusing based on technical jargon (like
 If you decommission a server, you can return its hostname to the usable
 pool, thereby uncommenting it in the wordlist:
 
-    $ ./genhost -jester
+    $ ./genhost del jester
 
 You can also print a list of the hostnames currently marked as in use:
 
-    $ ./genhost ?
+    $ ./genhost list
     romeo
     holiday
     spiral

--- a/genhost
+++ b/genhost
@@ -19,12 +19,12 @@ rand() {
 # check for a positive integer argument
 if [[ -z $1 ]]; then
   printf 'Usage:\n'
-  printf '  genhost +<integer>\n    Generate hostnames by randomly picking unused names from the wordlist\n'
-  printf '  genhost -<hostname>\n    Return a decommissioned hostname to the available pool\n'
-  printf '  genhost ?\n    Print a list of all hostnames currently in use\n'
+  printf '  genhost add <integer>\n    Generate hostnames by randomly picking unused names from the wordlist\n'
+  printf '  genhost del <hostname>\n    Return a decommissioned hostname to the available pool\n'
+  printf '  genhost list\n    Print a list of all hostnames currently in use\n'
   exit 1
 else
-  if [[ $1 == +[0-9]* ]]; then
+  if [[ $1 == "add" ]] && [[ $2 == [0-9]* ]]; then
     # read the word list into memory, removing commented words;
     # then remove the trailing empty element, if any:
     #    http://mywiki.wooledge.org/BashFAQ/005#Handling_newlines_.28or_lack_thereof.29_at_the_end_of_a_file
@@ -33,7 +33,7 @@ else
       [[ ${lines[n-1]} ]] || unset -v 'lines[--n]'
 
     # output the random hostname(s)
-    for i in $(seq $1); do
+    for i in $(seq $2); do
       if [[ $n -eq 0 ]]; then
         printf 'genhost: no more available hostnames left in file %s\n' "$wordlist" >&2
         exit 1
@@ -60,10 +60,8 @@ else
       lines=(${lines[@]:0:$r} ${lines[@]:$(( $r + 1 ))})
       n=$(( n - 1 ))
     done
-    exit 0 
-  elif [[ $1 == -[A-Za-z]* ]]; then
-    # strip the leading dash
-    token=$(echo $1 | tail -c +2)
+  elif [[ $1 == "del" ]] && [[ $2 == [A-Za-z]* ]]; then
+    token=${2#-}
     # find it in the wordlist and uncomment if it's there
     case $OSTYPE in
       darwin*)
@@ -76,9 +74,8 @@ else
         sed -i "s/#$token/$token/" "$wordlist"
         ;;
     esac
-  elif [[ $1 == \? ]]; then
+  elif [[ $1 == "list" ]]; then
     grep "#" wordlist | sed 's/#//'
-    exit 0
   else
     printf 'genhost: invalid input\n' >&2
     exit 1

--- a/genhost
+++ b/genhost
@@ -19,12 +19,12 @@ rand() {
 # check for a positive integer argument
 if [[ -z $1 ]]; then
   printf 'Usage:\n'
-  printf '  genhost add <integer>\n    Generate hostnames by randomly picking unused names from the wordlist\n'
-  printf '  genhost del <hostname>\n    Return a decommissioned hostname to the available pool\n'
+  printf '  genhost <integer>\n    Generate hostnames by randomly picking unused names from the wordlist\n'
+  printf '  genhost reuse <hostname>\n    Return a decommissioned hostname to the available pool\n'
   printf '  genhost list\n    Print a list of all hostnames currently in use\n'
   exit 1
 else
-  if [[ $1 == "add" ]] && [[ $2 == [0-9]* ]]; then
+  if [[ $1 == [0-9]* ]]; then
     # read the word list into memory, removing commented words;
     # then remove the trailing empty element, if any:
     #    http://mywiki.wooledge.org/BashFAQ/005#Handling_newlines_.28or_lack_thereof.29_at_the_end_of_a_file
@@ -33,7 +33,7 @@ else
       [[ ${lines[n-1]} ]] || unset -v 'lines[--n]'
 
     # output the random hostname(s)
-    for i in $(seq $2); do
+    for i in $(seq $1); do
       if [[ $n -eq 0 ]]; then
         printf 'genhost: no more available hostnames left in file %s\n' "$wordlist" >&2
         exit 1
@@ -60,7 +60,7 @@ else
       lines=(${lines[@]:0:$r} ${lines[@]:$(( $r + 1 ))})
       n=$(( n - 1 ))
     done
-  elif [[ $1 == "del" ]] && [[ $2 == [A-Za-z]* ]]; then
+  elif [[ $1 == "reuse" ]] && [[ $2 == [A-Za-z]* ]]; then
     token=${2#-}
     # find it in the wordlist and uncomment if it's there
     case $OSTYPE in

--- a/genhost
+++ b/genhost
@@ -18,50 +18,71 @@ rand() {
 
 # check for a positive integer argument
 if [[ -z $1 ]]; then
-  printf 'Usage: genhost <integer>\n'
-  printf 'Generate unused hostnames by randomly picking from a word list\n'
+  printf 'Usage:\n'
+  printf '  genhost +<integer>\n    Generate hostnames by randomly picking unused names from the wordlist\n'
+  printf '  genhost -<hostname>\n    Return a decommissioned hostname to the available pool\n'
+  printf '  genhost ?\n    Print a list of all hostnames currently in use\n'
   exit 1
 else
-  if [[ $1 == *[!0-9]* ]]; then
-    printf 'genhost: "%d" is not a positive integer\n' "$1" >&2
+  if [[ $1 == +[0-9]* ]]; then
+    # read the word list into memory, removing commented words;
+    # then remove the trailing empty element, if any:
+    #    http://mywiki.wooledge.org/BashFAQ/005#Handling_newlines_.28or_lack_thereof.29_at_the_end_of_a_file
+    unset lines n
+    while IFS= read -r 'lines[n++]'; do :; done < <(sed '/^#/d' "$wordlist")
+      [[ ${lines[n-1]} ]] || unset -v 'lines[--n]'
+
+    # output the random hostname(s)
+    for i in $(seq $1); do
+      if [[ $n -eq 0 ]]; then
+        printf 'genhost: no more available hostnames left in file %s\n' "$wordlist" >&2
+        exit 1
+      fi
+
+      # pick a random available word
+      rand $n
+      printf '%s.%s\n' "${lines[r]}" "$domain"
+
+      # mark the word as used in the word list
+      case $OSTYPE in
+        darwin*)
+          sed -i '' "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
+          ;;
+        linux*)
+          sed -i "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
+          ;;
+        msys*)
+          sed -i "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
+          ;;
+      esac
+
+      # remove the used word from the array to prevent duplicates
+      lines=(${lines[@]:0:$r} ${lines[@]:$(( $r + 1 ))})
+      n=$(( n - 1 ))
+    done
+    exit 0 
+  elif [[ $1 == -[A-Za-z]* ]]; then
+    # strip the leading dash
+    token=$(echo $1 | tail -c +2)
+    # find it in the wordlist and uncomment if it's there
+    case $OSTYPE in
+      darwin*)
+        sed -i '' "s/#$token/$token/" "$wordlist"
+        ;;
+      linux*)
+        sed -i "s/#$token/$token/" "$wordlist"
+        ;;
+      msys*)
+        sed -i "s/#$token/$token/" "$wordlist"
+        ;;
+    esac
+  elif [[ $1 == \? ]]; then
+    grep "#" wordlist | sed 's/#//'
+    exit 0
+  else
+    printf 'genhost: invalid input\n' >&2
     exit 1
   fi
 fi
-
-# read the word list into memory, removing commented words;
-# then remove the trailing empty element, if any:
-#    http://mywiki.wooledge.org/BashFAQ/005#Handling_newlines_.28or_lack_thereof.29_at_the_end_of_a_file
-unset lines n
-while IFS= read -r 'lines[n++]'; do :; done < <(sed '/^#/d' "$wordlist")
-[[ ${lines[n-1]} ]] || unset -v 'lines[--n]'
-
-# output the random hostname(s)
-for i in $(seq $1); do
-  if [[ $n -eq 0 ]]; then
-    printf 'genhost: no more available hostnames left in file %s\n' "$wordlist" >&2
-    exit 1
-  fi
-
-  # pick a random available word
-  rand $n
-  printf '%s.%s\n' "${lines[r]}" "$domain"
-
-  # mark the word as used in the word list
-  case $OSTYPE in
-    darwin*)
-      sed -i '' "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
-      ;;
-    linux*)
-      sed -i "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
-      ;;
-    msys*)
-      sed -i "s/^${lines[r]}\$/#${lines[r]}/" "$wordlist"
-      ;;
-  esac
-
-  # remove the used word from the array to prevent duplicates
-  lines=(${lines[@]:0:$r} ${lines[@]:$(( $r + 1 ))})
-  n=$(( n - 1 ))
-done
 
 exit 0


### PR DESCRIPTION
I love the idea of your utility, as I've just been using `shuf -n 1 wordlist` until now, but I think these functions will make it more useful as a hostname management tool.