### PR TITLE
Fix wordlist handling, updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ a shared Git repository so names do not get reused:
     $ git add wordlist
     $ git commit
     $ git push
+
+### Environment Variables
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `GENHOST_DOMAIN` | The domain name to append to generated hostnames | example.com |
+
+    $ export GENHOST_DOMAIN=github.com
+    $ ./genhost 3
+    cover.github.com
+    kilo.github.com
+    open.github.com

--- a/README.md
+++ b/README.md
@@ -45,9 +45,14 @@ a shared Git repository so names do not get reused:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `GENHOST_DOMAIN` | The domain name to append to generated hostnames | example.com |
+| `GENHOST_WORDLIST` | Filename of the word list to use, relative to genhost directory | wordlist |
 
     $ export GENHOST_DOMAIN=github.com
     $ ./genhost 3
     cover.github.com
     kilo.github.com
     open.github.com
+
+    $ export GENHOST_WORDLIST=colors.txt
+    $ ./genhost 1
+    yellow.github.com

--- a/genhost
+++ b/genhost
@@ -4,8 +4,19 @@
 # genhost - generate unused hostnames by randomly picking from a word list
 #
 
-readonly wordlist=$(dirname $0)/wordlist
+# script path variables
+readonly script=$(realpath $0)
+readonly script_name=$(basename $script)
+readonly script_dir=$(dirname $script)
+
+readonly wordlist=${GENHOST_WORDLIST:-wordlist}
 readonly domain=${GENHOST_DOMAIN:-example.com}
+
+# validate path to word list file
+if [[ "$wordlist" == *".."* ]] || [ "$(basename $wordlist)" == "$script_name" ]; then
+    printf 'genhost: invalid word list file: %s\n' $wordlist
+    exit 1
+fi
 
 # http://mywiki.wooledge.org/BashFAQ/026
 

--- a/genhost
+++ b/genhost
@@ -75,7 +75,7 @@ else
 			;;
 		esac
 	elif [[ $1 == "list" ]]; then
-		grep "#" wordlist | sed 's/#//'
+		grep "#" "$wordlist" | sed 's/#//'
 	else
 		printf 'genhost: invalid input\n' >&2
 		exit 1

--- a/genhost
+++ b/genhost
@@ -4,7 +4,7 @@
 # genhost - generate unused hostnames by randomly picking from a word list
 #
 
-readonly wordlist='wordlist'
+readonly wordlist=$(dirname $0)/wordlist
 readonly domain=${GENHOST_DOMAIN:-example.com}
 
 # http://mywiki.wooledge.org/BashFAQ/026


### PR DESCRIPTION
**Fixes**
- Fix hard-coded wordlist reference

**Documentation**
- Added environment variable section to the README

**Enhancements**
- Look for wordlist in genhost directory instead of current directory
  (This is so you can run the script from any directory and the script can find your wordlist)
